### PR TITLE
feat: add sparse matrix handling

### DIFF
--- a/modAL/__init__.py
+++ b/modAL/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     'classifier_uncertainty', 'classifier_margin', 'classifier_entropy',
     'uncertainty_sampling', 'margin_sampling', 'entropy_sampling',
     'vote_entropy', 'consensus_entropy', 'KL_max_disagreement',
-    'vote_entropy_sampling', 'consensus_entropy_sampling', 'max_disagreement_sampling', 'max_std_sampling'
+    'vote_entropy_sampling', 'consensus_entropy_sampling', 'max_disagreement_sampling', 'max_std_sampling',
     'information_density',
     'ranked_batch', 'uncertainty_batch_sampling'
 ]

--- a/modAL/batch.py
+++ b/modAL/batch.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.sparse as sp
 from sklearn.metrics.pairwise import pairwise_distances
 
-from modAL.utils.combination import data_vstack
+from modAL.utils.data import data_vstack
 from modAL.models import BaseCommittee, BaseLearner
 from modAL.uncertainty import classifier_uncertainty
 

--- a/modAL/density.py
+++ b/modAL/density.py
@@ -49,8 +49,8 @@ def information_density(X, similarity_measure=cosine_similarity):
         The information density for each sample.
 
     """
-    inf_density = np.zeros(shape=(len(X),))
+    inf_density = np.zeros(shape=(X.shape[0],))
     for X_idx, X_inst in enumerate(X):
         inf_density[X_idx] = sum(similarity_measure(X_inst, X_j) for X_j in X)
 
-    return inf_density/len(X)
+    return inf_density/X.shape[0]

--- a/modAL/models.py
+++ b/modAL/models.py
@@ -111,7 +111,7 @@ class BaseLearner(ABC, BaseEstimator):
         :param fit_kwargs: Keyword arguments to be passed to the fit method of the predictor.
         :type fit_kwargs: keyword arguments
         """
-        X, y = check_X_y(X, y, accept_sparse=True)
+        X, y = check_X_y(X, y, accept_sparse=True, ensure_2d=False, multi_output=True)
 
         if not bootstrap:
             self.estimator.fit(X, y, **fit_kwargs)
@@ -145,7 +145,7 @@ class BaseLearner(ABC, BaseEstimator):
         When using scikit-learn estimators, calling this method will make the
         ActiveLearner forget all training data it has seen!
         """
-        self.X_training, self.y_training = check_X_y(X, y, accept_sparse=True)
+        self.X_training, self.y_training = check_X_y(X, y, accept_sparse=True, ensure_2d=False, multi_output=True)
         return self._fit_to_known(bootstrap=bootstrap, **fit_kwargs)
 
     def predict(self, X, **predict_kwargs):

--- a/modAL/models.py
+++ b/modAL/models.py
@@ -13,7 +13,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.utils import check_X_y
 
 from modAL.utils.validation import check_class_labels, check_class_proba
-from modAL.utils.combination import data_vstack
+from modAL.utils.data import data_vstack
 from modAL.uncertainty import uncertainty_sampling
 from modAL.disagreement import vote_entropy_sampling, max_std_sampling
 
@@ -60,7 +60,7 @@ class BaseLearner(ABC, BaseEstimator):
         have to agree with the training samples which the
         classifier has seen.
         """
-        X, y = check_X_y(X, y, accept_sparse=True, ensure_2d=False, multi_output=True)
+        check_X_y(X, y, accept_sparse=True, ensure_2d=False, allow_nd=True, multi_output=True)
 
         if self.X_training is None:
             self.X_training = X
@@ -72,7 +72,6 @@ class BaseLearner(ABC, BaseEstimator):
             except ValueError:
                 raise ValueError('the dimensions of the new training data and label must'
                                  'agree with the training data and labels provided so far')
-
 
     def _fit_to_known(self, bootstrap=False, **fit_kwargs):
         """
@@ -111,7 +110,7 @@ class BaseLearner(ABC, BaseEstimator):
         :param fit_kwargs: Keyword arguments to be passed to the fit method of the predictor.
         :type fit_kwargs: keyword arguments
         """
-        X, y = check_X_y(X, y, accept_sparse=True, ensure_2d=False, multi_output=True)
+        check_X_y(X, y, accept_sparse=True, ensure_2d=False, allow_nd=True, multi_output=True)
 
         if not bootstrap:
             self.estimator.fit(X, y, **fit_kwargs)
@@ -145,7 +144,8 @@ class BaseLearner(ABC, BaseEstimator):
         When using scikit-learn estimators, calling this method will make the
         ActiveLearner forget all training data it has seen!
         """
-        self.X_training, self.y_training = check_X_y(X, y, accept_sparse=True, ensure_2d=False, multi_output=True)
+        check_X_y(X, y, accept_sparse=True, ensure_2d=False, allow_nd=True, multi_output=True)
+        self.X_training, self.y_training = X, y
         return self._fit_to_known(bootstrap=bootstrap, **fit_kwargs)
 
     def predict(self, X, **predict_kwargs):

--- a/modAL/uncertainty.py
+++ b/modAL/uncertainty.py
@@ -36,7 +36,7 @@ def classifier_uncertainty(classifier, X, **predict_proba_kwargs):
     try:
         classwise_uncertainty = classifier.predict_proba(X, **predict_proba_kwargs)
     except NotFittedError:
-        return np.ones(shape=(len(X), ))
+        return np.ones(shape=(X.shape[0], ))
 
     # for each point, select the maximum uncertainty
     uncertainty = 1 - np.max(classwise_uncertainty, axis=1)

--- a/modAL/utils/combination.py
+++ b/modAL/utils/combination.py
@@ -1,12 +1,4 @@
 import numpy as np
-import scipy.sparse as sp
-
-
-def data_vstack(blocks):
-    """Stack vertically both sparse and dense arrays."""
-    if sp.issparse(blocks[0]):
-        return sp.vstack(blocks)
-    return np.concatenate(blocks)
 
 
 def make_linear_combination(*functions, weights=None):

--- a/modAL/utils/combination.py
+++ b/modAL/utils/combination.py
@@ -1,4 +1,12 @@
 import numpy as np
+import scipy.sparse as sp
+
+
+def data_vstack(blocks):
+    """Stack vertically both sparse and dense arrays."""
+    if sp.issparse(blocks[0]):
+        return sp.vstack(blocks)
+    return np.concatenate(blocks)
 
 
 def make_linear_combination(*functions, weights=None):

--- a/modAL/utils/data.py
+++ b/modAL/utils/data.py
@@ -1,0 +1,9 @@
+import numpy as np
+import scipy.sparse as sp
+
+
+def data_vstack(blocks):
+    """Stack vertically both sparse and dense arrays."""
+    if sp.issparse(blocks[0]):
+        return sp.vstack(blocks)
+    return np.concatenate(blocks)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -538,7 +538,7 @@ class TestActiveLearner(unittest.TestCase):
                     # 1. len(X_new) != len(y_new)
                     X_new = np.random.rand(n_new_samples, n_features)
                     y_new = np.random.randint(0, 2, size=(2*n_new_samples,))
-                    self.assertRaises(AssertionError, learner._add_training_data, X_new, y_new)
+                    self.assertRaises(ValueError, learner._add_training_data, X_new, y_new)
                     # 2. X_new has wrong dimensions
                     X_new = np.random.rand(n_new_samples, 2*n_features)
                     y_new = np.random.randint(0, 2, size=(n_new_samples,))


### PR DESCRIPTION
In order to be able to experiment with sparse inputs, I refactored some base functionality of the library as well as uncertainty_batch_sampling query strategy.
All tests and corresponding example work as before.